### PR TITLE
Add informeSeleccion06 with card-based experience and training layout

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccion06/06.css/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion06/06.css/config.json
@@ -1,0 +1,15 @@
+{
+    "name": "06.css",
+    "sharedHelpersScope": null,
+    "creationDate": {
+        "$$date": 1754662710165
+    },
+    "modificationDate": {
+        "$$date": 1754662719454
+    },
+    "shortid": "06css",
+    "inheritedReadPermissions": [],
+    "inheritedEditPermissions": [],
+    "_id": "asset06css",
+    "$entitySet": "assets"
+}

--- a/data/informes/informesSeleccion/informeSeleccion06/06.css/content.css
+++ b/data/informes/informesSeleccion/informeSeleccion06/06.css/content.css
@@ -1,0 +1,201 @@
+/* ====== Ajustes generales / A4 Horizontal ====== */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: #1a202c;
+  background: #f5f7fb; /* leve gris azulado para pantalla */
+}
+
+/* Tamaño y márgenes de página impresos */
+@page {
+  size: A4 landscape;
+  margin: 18mm; /* MÁS margen alrededor */
+}
+
+/* Contenedor del documento (un poco de aire extra en pantalla) */
+.doc {
+  max-width: 1120px;
+  margin: 24px auto;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Cada "page" (sección de página) */
+.page {
+  padding: 24px 28px; /* MÁS margen interno */
+  page-break-after: always; /* la portada forzará salto */
+  background: #fff;
+}
+.page:last-child { page-break-after: auto; }
+
+/* ====== Portada ====== */
+.cover {
+  position: relative;
+  min-height: 180mm; /* asegura una altura generosa en landscape */
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 24px;
+  align-items: center;
+}
+
+/* Bloque texto portada */
+.cover__info {
+  z-index: 2;
+}
+.cover__title {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+  margin: 0 0 8px;
+  color: #111827;
+}
+.cover__subtitle {
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 18px;
+}
+.cover__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  row-gap: 8px;
+  column-gap: 12px;
+  font-size: 13px;
+  color: #374151;
+}
+.cover__label { color: #6b7280; }
+.brand {
+  margin-top: 18px;
+  font-weight: 800;
+  letter-spacing: .5px;
+}
+
+/* Bloque geométrico portada (SVG) */
+.cover__art {
+  position: relative;
+  min-height: 120mm;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: linear-gradient(135deg, #fff 0%, #f8fafc 40%, #eef2ff 100%);
+}
+.cover__art svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Sello/confidencial */
+.badge {
+  display: inline-block;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 4px 10px;
+  background: #f1f5f9;
+  font-weight: 700;
+}
+
+/* ====== Header y estructura contenidos ====== */
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  border-bottom: 2px solid #e5e7eb;
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+}
+.company-name { font-size: 22px; font-weight: 800; letter-spacing: 0.5px; }
+.company-subtitle { font-size: 12px; color: #6b7280; margin-top: 2px; }
+.candidate-name { font-size: 16px; font-weight: 700; }
+.score-badge { display: inline-flex; align-items: center; gap: 6px; background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 999px; padding: 4px 10px; font-size: 12px; margin-top: 6px; }
+.score-value { font-weight: 800; }
+
+/* ====== Grid principal ====== */
+.main-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.span-2 { grid-column: span 2; }
+.span-full { grid-column: 1 / -1; }
+
+/* ====== Módulos ====== */
+.module {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  overflow: hidden;
+
+  /* Evitar partir módulos entre páginas si cabe razonablemente */
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.module-header { background: #f8fafc; border-bottom: 1px solid #e5e7eb; padding: 10px 14px; }
+.module-title { font-size: 14px; font-weight: 700; color: #111827; }
+.module-content { padding: 14px; }
+
+.h3 { font-size: 12px; font-weight: 700; color: #111827; margin: 0 0 12px; padding-bottom: 8px; border-bottom: 2px solid #e5e7eb; }
+.text-content p { margin: 0 0 8px; line-height: 1.45; color: #1f2937; }
+
+/* ====== Info personal ====== */
+.info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.info-item {
+  display: grid; grid-template-columns: 28px 1fr; gap: 8px; align-items: start;
+  padding: 10px; border: 1px solid #e5e7eb; border-radius: 8px; background: #fafafa;
+
+  break-inside: avoid; page-break-inside: avoid; /* no partir items */
+}
+.info-item.span-2 { grid-column: span 2; }
+.info-icon { font-size: 16px; line-height: 1; }
+.info-label { font-size: 11px; color: #6b7280; }
+.info-value { font-size: 13px; font-weight: 600; color: #111827; }
+.info-secondary { font-size: 12px; color: #6b7280; margin-top: 4px; }
+
+/* ====== Evaluación ====== */
+.eval-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.eval-card {
+  border: 1px solid #e5e7eb; border-radius: 10px; background: #fcfcfd;
+  break-inside: avoid; page-break-inside: avoid;
+}
+.card-title { padding: 10px 12px; border-bottom: 1px solid #e5e7eb; font-size: 12px; font-weight: 700; color: #111827; background: #f9fafb; }
+.card-content { padding: 12px; }
+.card-content p { margin: 0 0 8px; line-height: 1.45; page-break-inside: avoid; }
+
+/* ====== Competencias ====== */
+.comp-item {
+  border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fcfcfd;
+  break-inside: avoid; page-break-inside: avoid;
+}
+.comp-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+.comp-name { font-weight: 700; }
+.comp-score { font-size: 12px; color: #374151; }
+.comp-obs p { margin: 0 0 6px; page-break-inside: avoid; }
+
+/* ====== Skills ====== */
+.mb-24 { margin-bottom: 24px; }
+.skills-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.skill-item {
+  display: flex; justify-content: space-between; align-items: center;
+  border: 1px solid #e5e7eb; border-radius: 8px; padding: 8px; background: #f9fafb;
+  break-inside: avoid; page-break-inside: avoid;
+}
+.skill-name { font-size: 13px; }
+.skill-level { font-size: 12px; color: #6b7280; }
+
+/* ====== Experiencia (cards) ====== */
+.exp-list { display: flex; flex-direction: column; gap: 12px; }
+.exp-card { border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fcfcfd; break-inside: avoid; page-break-inside: avoid; }
+.exp-header { display: flex; justify-content: space-between; margin-bottom: 4px; }
+.exp-company { font-weight: 600; }
+.exp-period { font-size: 12px; color: #6b7280; }
+.exp-position { font-size: 13px; font-weight: 700; margin-bottom: 4px; }
+.exp-function { margin: 0 0 4px; line-height: 1.45; }
+
+/* ====== Formación (cards) ====== */
+.form-list { display: flex; flex-direction: column; gap: 12px; }
+.form-card { border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fcfcfd; break-inside: avoid; page-break-inside: avoid; }
+.form-row { display: flex; justify-content: space-between; margin-bottom: 4px; }
+.form-title { font-weight: 600; }
+.form-year { font-size: 12px; color: #6b7280; }
+.form-center { font-size: 12px; color: #374151; }
+.form-level { font-size: 12px; color: #6b7280; }

--- a/data/informes/informesSeleccion/informeSeleccion06/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion06/config.json
@@ -1,0 +1,6 @@
+{
+    "_id": "newId06",
+    "shortid": "Sel06",
+    "$entitySet": "folders",
+    "name": "informeSeleccion06"
+}

--- a/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion0006/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion0006/config.json
@@ -1,0 +1,14 @@
+{
+    "name": "informeSeleccion0006",
+    "shortid": "data06",
+    "creationDate": {
+        "$$date": 1754662852448
+    },
+    "modificationDate": {
+        "$$date": 1754662852448
+    },
+    "inheritedReadPermissions": [],
+    "inheritedEditPermissions": [],
+    "_id": "data06id",
+    "$entitySet": "data"
+}

--- a/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion0006/dataJson.json
+++ b/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion0006/dataJson.json
@@ -1,0 +1,321 @@
+{
+    "idInformeCvPublicacion": 10006,
+    "idPedidoMaster": 320033,
+    "fechaPublicacion": "2025-06-12T15:43:30.1700000\u002B00:00",
+    "publicado": true,
+    "resumen": null,
+    "idTipoInforme": 2,
+    "idEmpresaCentro": 0,
+    "idUsuarioCreador": 0,
+    "datosPersonales": {
+        "idInformeCvPublicacionDatosPersonales": 10006,
+        "idInformeCvPublicacion": 10006,
+        "nombreCompleto": "Alberto Delgado Ortiz",
+        "foto": "34528.jpg",
+        "codigoPostal": "48903",
+        "municipio": "Barakaldo",
+        "pais": "Espa\u00F1a",
+        "direccionTexto": "Paseo cirilo sagastagoitia n 14 8 b izq",
+        "poblacion": "Lutxana",
+        "email": "delgaindar@hotmail.com",
+        "telefonoMovil": "\u002B34692714020",
+        "nif": "30686865N",
+        "fechaNacimiento": "1986-04-23T00:00:00.0000000\u002B02:00",
+        "edad": 39
+    },
+    "informe": {
+        "idInformeCvPublicacionInforme": 10006,
+        "idInformeCvPublicacion": 10006,
+        "tipoInforme": 0,
+        "valoracion": "Candidata finalista. Presenta un perfil t\u00E9cnico y personal alineado con los requerimientos del puesto. Su experiencia previa, actitud y disponibilidad inmediata hacen que sea una opci\u00F3n muy v\u00E1lida para el rol.",
+        "puntuacion": 1.5,
+        "aspectosPersonales": "Persona responsable, met\u00F3dica y con alta orientaci\u00F3n al orden y la planificaci\u00F3n. Transmite seriedad, compromiso y estabilidad. Destaca por su trato amable y profesional.",
+        "trayectoriaFormativa": "Formaci\u00F3n en administraci\u00F3n y ofim\u00E1tica, con conocimientos actualizados en herramientas de gesti\u00F3n y entorno Office. Ha complementado su perfil con cursos espec\u00EDficos relacionados con gesti\u00F3n documental y atenci\u00F3n al cliente.",
+        "trayectoriaProfesional": "Amplia experiencia como administrativa en distintas empresas, gestionando documentaci\u00F3n, atenci\u00F3n telef\u00F3nica, bases de datos y soporte a distintos departamentos. Conocimiento de herramientas ERP y trato con proveedores y clientes.",
+        "entrevistaPersonal": "Durante la entrevista mostr\u00F3 seguridad, claridad en la exposici\u00F3n y buena capacidad para estructurar sus ideas. Se expresa con correcci\u00F3n, mantiene buena escucha activa y demuestra inter\u00E9s por el puesto. Resalta su enfoque pr\u00E1ctico y resolutivo.",
+        "datosInteres": "Alta disponibilidad, posibilidad de incorporaci\u00F3n inmediata y experiencia en entornos con alto volumen de tareas administrativas. Buena adaptaci\u00F3n a distintos entornos de trabajo y equipos.",
+        "motivoPresentacion": "Perfil altamente adecuado para funciones administrativas. Aporta experiencia, madurez profesional, compromiso y capacidad de adaptaci\u00F3n. Puede incorporarse con agilidad a tareas diversas dentro del \u00E1rea.",
+        "conocimientos": null,
+        "adecuacion": null,
+        "motivacion": null,
+        "evolucionProfesional": null,
+        "potencial": null
+    },
+    "acreditaciones": [
+        {
+            "idInformeCvPublicacionAcreditacion": 10002,
+            "idInformeCvPublicacion": 10006,
+            "tipoAcreditacion": "6",
+            "fecha": "2025-06-04T00:00:00.0000000\u002B02:00",
+            "descripcion": "Tarjeta profesional del metal",
+            "acredita": false,
+            "horas": 3,
+            "orden": 1
+        }
+    ],
+    "adjuntos": [
+        {
+            "idInformeCvPublicacionAdjunto": 2,
+            "idInformeCvPublicacion": 10006,
+            "ruta": "prueba/CDFF",
+            "duracionHoras": null,
+            "tipoAdjunto": {
+                "id": 1,
+                "value": "Prueba Psicotecnica"
+            },
+            "orden": 1
+        }
+    ],
+    "competencias": [
+        {
+            "idInformeCvPublicacionCompetencia": 10002,
+            "idInformeCvPublicacion": 10006,
+            "competencia": "Esmero",
+            "puntuacion": 2.5,
+            "observaciones": "Muestra una capacidad limitada para trabajar con precisi\u00F3n. Aunque hay un esfuerzo por mantener el orden y prestar atenci\u00F3n a los detalles, estos esfuerzos son inconsistentes y a menudo se ven eclipsados por la falta de concentraci\u00F3n. Aunque se reconocen los plazos y las normas, la capacidad para cumplirlos de manera efectiva es variable",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionCompetencia": 10003,
+            "idInformeCvPublicacion": 10006,
+            "competencia": "Sociabilidad",
+            "puntuacion": 2.5,
+            "observaciones": "La persona demuestra una capacidad b\u00E1sica para interactuar socialmente. Puede establecer relaciones y mantener conversaciones, pero a veces puede ser malinterpretado. La capacidad para trabajar en equipo y colaborar con los dem\u00E1s est\u00E1 presente, pero a\u00FAn necesita mejorar",
+            "orden": 2
+        }
+    ],
+    "experienciasLaborales": [
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10002,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Fcc s. a",
+            "puesto": "ADMINISTRATIVO/A COMERCIAL",
+            "funcionRealizada": "Atenci\u00F3n al p\u00FAblico",
+            "fechaInicio": "2005-04-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2005-10-01T00:00:00.0000000\u002B02:00",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10003,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Fcc s.a",
+            "puesto": "ADMINISTRATIVO/A DE FACTURACI\u00D3N",
+            "funcionRealizada": "Tareas variadas de administraci\u00F3n.",
+            "fechaInicio": "2006-05-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2010-03-01T00:00:00.0000000\u002B01:00",
+            "orden": 2
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10004,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Precicast bilbao",
+            "puesto": "CARRETILLERO/A RETR\u00C1CTIL",
+            "funcionRealizada": "Retrabajar piezas y ensayos no destructivos",
+            "fechaInicio": "2007-04-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2008-08-01T00:00:00.0000000\u002B02:00",
+            "orden": 3
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10005,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Eroski s. coop artea",
+            "puesto": "CONSULTOR/A SAP",
+            "funcionRealizada": "Creaci\u00F3n de softwares y dise\u00F1o de la arquitectura de los sistemas",
+            "fechaInicio": "2010-05-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2010-08-01T00:00:00.0000000\u002B02:00",
+            "orden": 4
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10006,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Leroy merl\u00EDn artea",
+            "puesto": "MANIPULADOR/A DE FRUTAS",
+            "funcionRealizada": "Todo tipo de tareas de almac\u00E9n",
+            "fechaInicio": "2010-09-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2012-11-01T00:00:00.0000000\u002B01:00",
+            "orden": 5
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10007,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Frutas iru",
+            "puesto": "MANIPULADOR/A DE FRUTAS",
+            "funcionRealizada": "Manipulaci\u00F3n de frutas y hortalizas",
+            "fechaInicio": "2013-05-01T00:00:00.0000000\u002B02:00",
+            "fechaFin": "2017-10-01T00:00:00.0000000\u002B02:00",
+            "orden": 6
+        },
+        {
+            "idInformeCvPublicacionExperienciaLaboral": 10008,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "Mercabilbao",
+            "puesto": "N/D",
+            "funcionRealizada": "",
+            "fechaInicio": null,
+            "fechaFin": null,
+            "orden": 7
+        }
+    ],
+    "formaciones": [
+        {
+            "idInformeCvPublicacionFormacion": 10002,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Primera etapa de la educacion secundarioa con titulo de graduado escolar o equivalente",
+            "nombre": null,
+            "centro": "Salesianos cruces",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2002-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10003,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Ense\u00F1anzas de bachillerato",
+            "nombre": "Bachillerato tecnol\u00F3gico",
+            "centro": "I. e. s.  elorrieta-errekamari",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2004-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 2
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10004,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Ense\u00F1anzas universitarias de segundo ciclo y equivalentes (Licenciado)",
+            "nombre": "T\u00E9cnico superior teleco e inform\u00E1tico",
+            "centro": "I. e. s.  minas",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2007-01-01T01:00:00.0000000\u002B01:00",
+            "orden": 3
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10005,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Ense\u00F1anzas universitarias de primer ciclo y equivalentes o personas que han aprobado tres cursos completos de una licenciatura o creditos equivalentes (Diplomado)",
+            "nombre": "T\u00E9cnico en emergencias sanitarias",
+            "centro": "Eurocultum",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2015-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 4
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10006,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Dise\u00F1o y documentaci\u00F3n t\u00E9cnica en sonorizaci\u00F3n industrial y.",
+            "centro": "Iefps tartanga",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2010-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 5
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10007,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Programador de sistemas",
+            "centro": "Fondo formaci\u00F3n euskadi",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2005-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 6
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10008,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Formaci\u00F3n empresarial",
+            "centro": "Dema",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2004-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 7
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10009,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Manipulador de alimentos",
+            "centro": "Forcalem",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2013-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 8
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10010,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Gesti\u00F3n de stock y log\u00EDstica b\u00E1sica",
+            "centro": "Cofes",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2017-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 9
+        },
+        {
+            "idInformeCvPublicacionFormacion": 10011,
+            "idInformeCvPublicacion": 10006,
+            "titulacionAcademica": "Otros estudios no oficiales",
+            "nombre": "Curso de carretillero",
+            "centro": "Laboris",
+            "titulo": true,
+            "duracionHoras": null,
+            "fechaFin": "2016-01-01T00:00:00.0000000\u002B00:00",
+            "orden": 10
+        }
+    ],
+    "idiomas": [
+        {
+            "idInformeCvPublicacionIdioma": 4,
+            "idInformeCvPublicacion": 10006,
+            "idioma": "Ingl\u00E9s",
+            "nivel": "B2",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionIdioma": 5,
+            "idInformeCvPublicacion": 10006,
+            "idioma": "Alem\u00E1n",
+            "nivel": "A2",
+            "orden": 2
+        }
+    ],
+    "aplicacionesInformaticas": [
+        {
+            "idInformeCvPublicacionInformatica": 3,
+            "idInformeCvPublicacion": 10006,
+            "aplicacion": "Excel",
+            "nivel": "B\u00E1sico",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionInformatica": 4,
+            "idInformeCvPublicacion": 10006,
+            "aplicacion": "Autocad",
+            "nivel": "Intermendio",
+            "orden": 2
+        }
+    ],
+    "referencias": [
+        {
+            "idInformeCvPublicacionReferencia": 3,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "ACINFA",
+            "funcionRealizada": "Log\u00EDstica",
+            "referencia": "Jefe Almac\u00E9n Jose Luis L\u00F3pez",
+            "orden": 1
+        },
+        {
+            "idInformeCvPublicacionReferencia": 4,
+            "idInformeCvPublicacion": 10006,
+            "empresa": "ASIDO",
+            "funcionRealizada": "PE\u00D3N",
+            "referencia": "Jefe Juan Mart\u00EDnez",
+            "orden": 2
+        }
+    ]
+}

--- a/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/config.json
@@ -1,0 +1,22 @@
+{
+    "name": "informeSeleccion006",
+    "recipe": "chrome-pdf",
+    "shortid": "Sel006",
+    "engine": "handlebars",
+    "data": {
+        "shortid": "data06"
+    },
+    "chrome": {
+        "printBackground": true
+    },
+    "creationDate": {
+        "$$date": 1754662802412
+    },
+    "modificationDate": {
+        "$$date": 1754662872208
+    },
+    "inheritedReadPermissions": [],
+    "inheritedEditPermissions": [],
+    "_id": "tmpl06",
+    "$entitySet": "templates"
+}

--- a/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/content.handlebars
+++ b/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/content.handlebars
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Informe GRUPOMPLEO - {{datosPersonales.nombreCompleto}}</title>
+  <style>{{{asset "06.css"}}}</style>
+</head>
+<body>
+  <div class="doc">
+
+    <!-- ====== PORTADA ====== -->
+    <section class="page cover">
+      <div class="cover__info">
+        <div class="badge">CONFIDENCIAL</div>
+        <h1 class="cover__title">Informe de Candidato</h1>
+        <div class="cover__subtitle">Evaluación profesional — Sector Industrial</div>
+
+        <div class="cover__meta">
+          <div class="cover__label">Candidato</div>
+          <div>{{datosPersonales.nombreCompleto}}</div>
+
+          <div class="cover__label">Empresa</div>
+          <div>GRUPOMPLEO</div>
+
+          <div class="cover__label">Tipo de informe</div>
+          <div>{{tipoInforme}}</div>
+
+          <div class="cover__label">Fecha</div>
+          <div>{{formatDate fechaEmision "year"}}-{{formatDate fechaEmision ""}}</div>
+
+          <div class="cover__label">ID</div>
+          <div>{{idInformeCvPublicacion}}</div>
+
+          <div class="cover__label">Elaborado por</div>
+          <div>{{autor}}</div>
+        </div>
+
+        <div class="brand">GRUPOMPLEO</div>
+        <div class="cover__subtitle">Transparencia • Legalidad • Cercanía • Industria</div>
+      </div>
+
+      <div class="cover__art" aria-hidden="true">
+        <!-- Geometría industrial (SVG sin assets externos) -->
+        <svg viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <linearGradient id="g1" x1="0" x2="1" y1="0" y2="1">
+              <stop offset="0%" stop-color="#fefce8"/>
+              <stop offset="100%" stop-color="#fde68a"/>
+            </linearGradient>
+            <linearGradient id="g2" x1="1" x2="0" y1="0" y2="1">
+              <stop offset="0%" stop-color="#e5e7eb"/>
+              <stop offset="100%" stop-color="#c7d2fe"/>
+            </linearGradient>
+          </defs>
+
+          <!-- Fondo cuadriculado sutil -->
+          <g opacity="0.35" stroke="#dbeafe" stroke-width="1">
+            <!-- líneas verticales -->
+            {{!-- malla 8px aprox a escala SVG --}}
+            {{!-- (en SVG estático, pre-dibujamos algunas líneas) --}}
+            <path d="M50 0 V800 M100 0 V800 M150 0 V800 M200 0 V800 M250 0 V800 M300 0 V800 M350 0 V800 M400 0 V800 M450 0 V800 M500 0 V800 M550 0 V800 M600 0 V800 M650 0 V800 M700 0 V800 M750 0 V800 M800 0 V800 M850 0 V800 M900 0 V800 M950 0 V800 M1000 0 V800 M1050 0 V800 M1100 0 V800" />
+            <!-- líneas horizontales -->
+            <path d="M0 50 H1200 M0 100 H1200 M0 150 H1200 M0 200 H1200 M0 250 H1200 M0 300 H1200 M0 350 H1200 M0 400 H1200 M0 450 H1200 M0 500 H1200 M0 550 H1200 M0 600 H1200 M0 650 H1200 M0 700 H1200 M0 750 H1200" />
+          </g>
+
+          <!-- Piezas geométricas -->
+          <rect x="620" y="120" width="460" height="220" rx="22" fill="url(#g2)" opacity="0.9"/>
+          <rect x="540" y="360" width="340" height="180" rx="18" fill="#fde68a" opacity="0.9"/>
+          <circle cx="980" cy="580" r="90" fill="url(#g1)" opacity="0.95"/>
+          <path d="M140 520 L340 520 L420 640 L220 640 Z" fill="#111827" opacity="0.06"/>
+          <path d="M260 180 L480 180 L560 280 L340 280 Z" fill="#111827" opacity="0.06"/>
+
+          <!-- Líneas de “cinta transportadora” -->
+          <g stroke="#9ca3af" stroke-width="6" opacity="0.4">
+            <line x1="140" y1="700" x2="520" y2="700"/>
+            <line x1="560" y1="700" x2="1040" y2="700"/>
+          </g>
+        </svg>
+      </div>
+    </section>
+
+    <!-- ====== CONTENIDO ====== -->
+    <section class="page">
+      <!-- HEADER PRINCIPAL -->
+      <div class="header">
+        <div>
+          <div class="company-name">GRUPOMPLEO</div>
+          <div class="company-subtitle">Recursos Humanos • Sector Industrial</div>
+        </div>
+        <div style="text-align: right;">
+          <div class="candidate-name">{{datosPersonales.nombreCompleto}}</div>
+          {{#if informe.puntuacion}}
+            <div class="score-badge">
+              <span class="score-value">{{informe.puntuacion}}</span>/3 Puntuación
+            </div>
+          {{/if}}
+        </div>
+      </div>
+
+      <!-- GRILLA PRINCIPAL -->
+      <div class="main-grid">
+
+        <!-- INFORMACIÓN PERSONAL -->
+        {{#if (or datosPersonales.email datosPersonales.telefonoMovil datosPersonales.direccionTexto)}}
+        <div class="module">
+          <div class="module-header">
+            <div class="module-title">Información Personal</div>
+          </div>
+          <div class="module-content">
+            <div class="info-grid">
+              {{#if datosPersonales.email}}
+              <div class="info-item">
+                <div class="info-icon">📧</div>
+                <div>
+                  <div class="info-label">Email</div>
+                  <div class="info-value">{{datosPersonales.email}}</div>
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if datosPersonales.telefonoMovil}}
+              <div class="info-item">
+                <div class="info-icon">📱</div>
+                <div>
+                  <div class="info-label">Teléfono</div>
+                  <div class="info-value">{{datosPersonales.telefonoMovil}}</div>
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if datosPersonales.direccionTexto}}
+              <div class="info-item span-2">
+                <div class="info-icon">📍</div>
+                <div>
+                  <div class="info-label">Dirección</div>
+                  <div class="info-value">{{datosPersonales.direccionTexto}}</div>
+                  {{#if datosPersonales.municipio}}
+                  <div class="info-secondary">{{datosPersonales.municipio}}, {{datosPersonales.pais}}</div>
+                  {{/if}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if datosPersonales.nif}}
+              <div class="info-item">
+                <div class="info-icon">🆔</div>
+                <div>
+                  <div class="info-label">NIF</div>
+                  <div class="info-value">{{datosPersonales.nif}}</div>
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if datosPersonales.edad}}
+              <div class="info-item">
+                <div class="info-icon">📅</div>
+                <div>
+                  <div class="info-label">Edad</div>
+                  <div class="info-value">{{datosPersonales.edad}} años</div>
+                </div>
+              </div>
+              {{/if}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- EVALUACIÓN PROFESIONAL -->
+        {{#if (or informe.valoracion informe.aspectosPersonales informe.entrevistaPersonal informe.trayectoriaFormativa informe.trayectoriaProfesional informe.datosInteres informe.motivoPresentacion)}}
+        <div class="module span-2">
+          <div class="module-header">
+            <div class="module-title">Evaluación Profesional</div>
+          </div>
+          <div class="module-content">
+            {{#if informe.valoracion}}
+            <div style="margin-bottom: 24px;">
+              <h3 class="h3">Valoración General</h3>
+              <div class="text-content">
+                {{#each (splitParagraphs informe.valoracion)}}
+                  <p>{{this}}</p>
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <div class="eval-grid">
+              {{#if informe.aspectosPersonales}}
+              <div class="eval-card">
+                <div class="card-title">Aspectos Personales</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.aspectosPersonales)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if informe.entrevistaPersonal}}
+              <div class="eval-card">
+                <div class="card-title">Entrevista Personal</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.entrevistaPersonal)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if informe.trayectoriaFormativa}}
+              <div class="eval-card">
+                <div class="card-title">Trayectoria Formativa</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.trayectoriaFormativa)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if informe.trayectoriaProfesional}}
+              <div class="eval-card">
+                <div class="card-title">Trayectoria Profesional</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.trayectoriaProfesional)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if informe.datosInteres}}
+              <div class="eval-card">
+                <div class="card-title">Datos de Interés</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.datosInteres)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+
+              {{#if informe.motivoPresentacion}}
+              <div class="eval-card">
+                <div class="card-title">Motivo de Presentación</div>
+                <div class="card-content">
+                  {{#each (splitParagraphs informe.motivoPresentacion)}}
+                    <p>{{this}}</p>
+                  {{/each}}
+                </div>
+              </div>
+              {{/if}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- COMPETENCIAS -->
+        {{#if competencias}}
+        <div class="module">
+          <div class="module-header">
+            <div class="module-title">Competencias</div>
+          </div>
+          <div class="module-content">
+            {{#each competencias}}
+            <div class="comp-item">
+              <div class="comp-header">
+                <div class="comp-name">{{competencia}}</div>
+                <div class="comp-score">{{puntuacion}}/5</div>
+              </div>
+              {{#if observaciones}}
+              <div class="comp-obs">
+                {{#each (splitParagraphs observaciones)}}
+                  <p>{{this}}</p>
+                {{/each}}
+              </div>
+              {{/if}}
+            </div>
+            {{/each}}
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- HABILIDADES TÉCNICAS -->
+        {{#if (or idiomas aplicacionesInformaticas acreditaciones)}}
+        <div class="module">
+          <div class="module-header">
+            <div class="module-title">Habilidades Técnicas</div>
+          </div>
+          <div class="module-content">
+            {{#if idiomas}}
+            <div class="mb-24">
+              <h3 class="h3">Idiomas</h3>
+              <div class="skills-grid">
+                {{#each idiomas}}
+                <div class="skill-item">
+                  <span class="skill-name">{{idioma}}</span>
+                  <span class="skill-level">{{nivel}}</span>
+                </div>
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            {{#if aplicacionesInformaticas}}
+            <div class="mb-24">
+              <h3 class="h3">Aplicaciones Informáticas</h3>
+              <div class="skills-grid">
+                {{#each aplicacionesInformaticas}}
+                <div class="skill-item">
+                  <span class="skill-name">{{aplicacion}}</span>
+                  <span class="skill-level">{{nivel}}</span>
+                </div>
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            {{#if acreditaciones}}
+            <div>
+              <h3 class="h3">Acreditaciones</h3>
+              <div class="acred-list">
+                {{#each acreditaciones}}
+                <div class="acred-item">
+                  <div class="acred-name">{{descripcion}}</div>
+                  {{#if horas}}
+                  <div class="acred-hours">{{horas}}h</div>
+                  {{/if}}
+                </div>
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- EXPERIENCIA LABORAL -->
+        {{#if experienciasLaborales}}
+        <div class="module span-full">
+          <div class="module-header">
+            <div class="module-title">Experiencia Laboral</div>
+          </div>
+          <div class="module-content">
+            <div class="exp-list">
+              {{#each experienciasLaborales}}
+              <div class="exp-card">
+                <div class="exp-header">
+                  <div class="exp-company">{{empresa}}</div>
+                  <div class="exp-period">{{formatDateRange fechaInicio fechaFin}}</div>
+                </div>
+                <div class="exp-position">{{puesto}}</div>
+                {{#each (splitParagraphs funcionRealizada)}}
+                <p class="exp-function">{{this}}</p>
+                {{/each}}
+              </div>
+              {{/each}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- FORMACIÓN ACADÉMICA -->
+        {{#if formaciones}}
+        <div class="module span-full">
+          <div class="module-header">
+            <div class="module-title">Formación Académica</div>
+          </div>
+          <div class="module-content">
+            <div class="form-list">
+              {{#each formaciones}}
+              <div class="form-card">
+                <div class="form-row">
+                  <div class="form-title">
+                    {{#if nombre}}
+                      {{nombre}}
+                    {{else}}
+                      {{titulacionAcademica}}
+                    {{/if}}
+                  </div>
+                  <div class="form-year">
+                    {{#if fechaFin}}
+                      {{formatDate fechaFin 'year'}}
+                    {{else}}
+                      N/D
+                    {{/if}}
+                  </div>
+                </div>
+                <div class="form-center">{{centro}}</div>
+                <div class="form-level">{{titulacionAcademica}}</div>
+              </div>
+              {{/each}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+
+        <!-- REFERENCIAS PROFESIONALES -->
+        {{#if referencias}}
+        <div class="module span-2">
+          <div class="module-header">
+            <div class="module-title">Referencias Profesionales</div>
+          </div>
+          <div class="module-content">
+            <div class="ref-grid">
+              {{#each referencias}}
+              <div class="ref-card">
+                <div class="ref-company">{{empresa}}</div>
+                <div class="ref-contact">{{referencia}}</div>
+                {{#if funcionRealizada}}
+                <div class="ref-function">{{funcionRealizada}}</div>
+                {{/if}}
+              </div>
+              {{/each}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+
+      </div>
+
+      <!-- FOOTER -->
+      <div class="footer">
+        <div class="footer-content">
+          <div>
+            <span class="footer-company">GRUPOMPLEO</span>
+            <span class="dot">•</span>
+            <span>Informe de Evaluación</span>
+          </div>
+          <div>
+            <span>ID: {{idInformeCvPublicacion}}</span>
+            <span class="dot">•</span>
+            <span class="footer-confidential">CONFIDENCIAL</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</body>
+</html>

--- a/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/helpers.js
+++ b/data/informes/informesSeleccion/informeSeleccion06/informeSeleccion006/helpers.js
@@ -1,0 +1,37 @@
+// Devolver true si alguno de los argumentos (excepto el último, que es options) es truthy
+function or() {
+  const args = Array.prototype.slice.call(arguments, 0, -1);
+  return args.some(Boolean);
+}
+
+// (Opcional) AND lógico por si lo necesitas en el futuro
+function and() {
+  const args = Array.prototype.slice.call(arguments, 0, -1);
+  return args.every(Boolean);
+}
+
+// formatea fechas muy simple: ahora solo usamos 'year'
+function formatDate(date, part) {
+  if (!date) return '';
+  const d = new Date(date);
+  if (isNaN(d)) return '';
+  if (part === 'year') return d.getFullYear();
+  return d.toISOString();
+}
+
+// separa texto en párrafos por líneas en blanco
+function splitParagraphs(str) {
+  if (!str) return [];
+  return String(str)
+    .trim()
+    .split(/\r?\n\s*\r?\n/) // párrafos separados por una o más líneas en blanco
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+// compone rango de fechas "YYYY - YYYY/Actual"
+function formatDateRange(start, end) {
+  const startYear = formatDate(start, 'year') || 'N/D';
+  const endYear = end ? formatDate(end, 'year') : 'Actual';
+  return `${startYear} - ${endYear}`;
+}


### PR DESCRIPTION
## Summary
- Duplicate informeSeleccion05 into informeSeleccion06 and switch asset reference to new `06.css`
- Replace experience and training tables with card-based lists and add `formatDateRange` helper
- Style new card components to avoid page breaks and improve readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b09cf904832ea7cbf786bf645476