### PR TITLE
Improve layout to handle variable-length sections

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccion05/05.css/content.css
+++ b/data/informes/informesSeleccion/informeSeleccion05/05.css/content.css
@@ -126,16 +126,37 @@ body {
   background: #fff;
   overflow: hidden;
 
-  /* Evitar partir módulos entre páginas si cabe razonablemente */
-  break-inside: avoid;
-  page-break-inside: avoid;
+  /* Permitir que los módulos se repartan entre páginas para evitar
+     grandes espacios en blanco. Los elementos internos gestionan
+     la ruptura para mantenerse íntegros. */
+  break-inside: auto;
+  page-break-inside: auto;
 }
-.module-header { background: #f8fafc; border-bottom: 1px solid #e5e7eb; padding: 10px 14px; }
+.module-header {
+  background: #f8fafc;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 10px 14px;
+  position: sticky;
+  top: 0;
+  z-index: 1; /* Indica contexto cuando el módulo continúa en otra página */
+}
 .module-title { font-size: 14px; font-weight: 700; color: #111827; }
 .module-content { padding: 14px; }
 
 .h3 { font-size: 12px; font-weight: 700; color: #111827; margin: 0 0 12px; padding-bottom: 8px; border-bottom: 2px solid #e5e7eb; }
-.text-content p { margin: 0 0 8px; line-height: 1.45; color: #1f2937; }
+.text-content p {
+  margin: 0 0 8px;
+  line-height: 1.45;
+  color: #1f2937;
+  page-break-inside: avoid; /* Mantener párrafos intactos */
+}
+
+/* Evitar que los listados y filas de tablas se partan entre páginas */
+ul, ol, li,
+table, thead, tbody, tr {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
 
 /* ====== Info personal ====== */
 .info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
@@ -175,4 +196,7 @@ body {
 .mb-24 { margin-bottom: 24px; }
 .skills-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 .skill-item {
-  display: flex; justify-content: s
+  display: flex; justify-content: space-between; align-items: center;
+  border: 1px solid #e5e7eb; border-radius: 8px; padding: 8px; background: #f9fafb;
+  break-inside: avoid; page-break-inside: avoid;
+}


### PR DESCRIPTION
## Summary
- allow modules to split across pages while keeping items intact
- show sticky headers and avoid page breaks inside items and lists
- complete skills section styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b521c340832e8eebdbee5684ee68