### PR TITLE
Add PDF header breadcrumbs to informeSeleccion005

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccion05/05.css/content.css
+++ b/data/informes/informesSeleccion/informeSeleccion05/05.css/content.css
@@ -114,6 +114,12 @@ body {
 .score-badge { display: inline-flex; align-items: center; gap: 6px; background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 999px; padding: 4px 10px; font-size: 12px; margin-top: 6px; }
 .score-value { font-weight: 800; }
 
+.crumb {
+  font-size: 10px;
+  color: #6b7280;
+  text-align: center;
+}
+
 /* ====== Grid principal ====== */
 .main-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 .span-2 { grid-column: span 2; }

--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/config.json
@@ -7,7 +7,10 @@
         "shortid": "fh6zH92Hz"
     },
     "chrome": {
-        "printBackground": true
+        "printBackground": true,
+        "marginTop": "20mm",
+        "headerHeight": "10mm",
+        "headerTemplate": "<div class='crumb'>{{modulo}} › {{seccion}} › {{apartado}} — pág. <span class='pageNumber'></span>/<span class='totalPages'></span></div>"
     },
     "creationDate": {
         "$$date": 1754662802412

--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/content.handlebars
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/content.handlebars
@@ -102,6 +102,7 @@
 
         <!-- INFORMACIÓN PERSONAL -->
         {{#if (or datosPersonales.email datosPersonales.telefonoMovil datosPersonales.direccionTexto)}}
+        {{{pdfAddPageItem { modulo: 'Información', seccion: 'Personal' }}}}
         <div class="module">
           <div class="module-header">
             <div class="module-title">Información Personal</div>
@@ -167,6 +168,7 @@
 
         <!-- EVALUACIÓN PROFESIONAL -->
         {{#if (or informe.valoracion informe.aspectosPersonales informe.entrevistaPersonal informe.trayectoriaFormativa informe.trayectoriaProfesional informe.datosInteres informe.motivoPresentacion)}}
+        {{{pdfAddPageItem { modulo: 'Evaluación', seccion: 'Profesional' }}}}
         <div class="module span-2">
           <div class="module-header">
             <div class="module-title">Evaluación Profesional</div>
@@ -256,6 +258,7 @@
 
         <!-- COMPETENCIAS -->
         {{#if competencias}}
+        {{{pdfAddPageItem { modulo: 'Competencias' }}}}
         <div class="module">
           <div class="module-header">
             <div class="module-title">Competencias</div>
@@ -282,6 +285,7 @@
 
         <!-- HABILIDADES TÉCNICAS -->
         {{#if (or idiomas aplicacionesInformaticas acreditaciones)}}
+        {{{pdfAddPageItem { modulo: 'Habilidades', seccion: 'Técnicas' }}}}
         <div class="module">
           <div class="module-header">
             <div class="module-title">Habilidades Técnicas</div>
@@ -336,6 +340,7 @@
 
         <!-- EXPERIENCIA LABORAL -->
         {{#if experienciasLaborales}}
+        {{{pdfAddPageItem { modulo: 'Experiencia', seccion: 'Laboral' }}}}
         <div class="module span-full">
           <div class="module-header">
             <div class="module-title">Experiencia Laboral</div>
@@ -380,6 +385,7 @@
 
         <!-- FORMACIÓN ACADÉMICA -->
         {{#if formaciones}}
+        {{{pdfAddPageItem { modulo: 'Formación', seccion: 'Académica' }}}}
         <div class="module span-full">
           <div class="module-header">
             <div class="module-title">Formación Académica</div>
@@ -425,6 +431,7 @@
 
         <!-- REFERENCIAS PROFESIONALES -->
         {{#if referencias}}
+        {{{pdfAddPageItem { modulo: 'Referencias', seccion: 'Profesionales' }}}}
         <div class="module span-2">
           <div class="module-header">
             <div class="module-title">Referencias Profesionales</div>


### PR DESCRIPTION
## Summary
- add Chrome header template with breadcrumb and margins
- tag each module with pdfAddPageItem so header reflects active section
- style breadcrumb header

## Testing
- `npm test` (fails: Could not read package.json)
- `npx jsreport help` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6899fbc977a0832eb9b10adfd252ee08