### PR TITLE
feat: add dynamic section headers for PDF reports

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/config.json
@@ -1,0 +1,12 @@
+{
+  "shortid": "r1U1YcO9m",
+  "name": "informeSeleccion005-header",
+  "recipe": "chrome-pdf",
+  "engine": "handlebars",
+  "chrome": {
+    "marginTop": "0cm",
+    "marginRight": "0cm",
+    "marginBottom": "0cm",
+    "marginLeft": "0cm"
+  }
+}

--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/content.handlebars
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/content.handlebars
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <style>
+      .header {
+        font-size: 10px;
+        color: #555;
+        text-align: right;
+        padding: 5px 20px;
+        border-bottom: 1px solid #ddd;
+      }
+    </style>
+  </head>
+  <body>
+    {{#each $pdf.pages}}
+      {{#if @index}}
+        <div style="page-break-before: always;"></div>
+      {{/if}}
+      {{#with (lookup ../$pdf.pages @index)}}
+        {{#if modulo}}
+          <div class="header">{{modulo}}{{#if seccion}} - {{seccion}}{{/if}}</div>
+        {{/if}}
+      {{/with}}
+    {{/each}}
+  </body>
+</html>

--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/config.json
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005/config.json
@@ -8,10 +8,15 @@
     },
     "chrome": {
         "printBackground": true,
-        "marginTop": "20mm",
-        "headerHeight": "10mm",
-        "headerTemplate": "<div class='crumb'>{{modulo}} › {{seccion}} › {{apartado}} — pág. <span class='pageNumber'></span>/<span class='totalPages'></span></div>"
+        "marginTop": "20mm"
     },
+    "pdfOperations": [
+        {
+            "type": "merge",
+            "templateShortid": "r1U1YcO9m",
+            "mergeWholeDocument": true
+        }
+    ],
     "creationDate": {
         "$$date": 1754662802412
     },


### PR DESCRIPTION
## Summary
- add pdf-utils header template that prints current modulo and seccion on each page
- merge the new header into informeSeleccion005 via pdfOperations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0a5aba70832ebbdf01cff54bd6b9