### PR TITLE
Use pageItems for header metadata

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/content.handlebars
+++ b/data/informes/informesSeleccion/informeSeleccion05/informeSeleccion005-header/content.handlebars
@@ -15,7 +15,7 @@
       {{#if @index}}
         <div style="page-break-before: always;"></div>
       {{/if}}
-      {{#with (lookup ../$pdf.pages @index)}}
+      {{#with (lookup ../$pdf.pageItems @index)}}
         {{#if modulo}}
           <div class="header">{{modulo}}{{#if seccion}} - {{seccion}}{{/if}}</div>
         {{/if}}


### PR DESCRIPTION
## Summary
- Read header info from `$pdf.pageItems` instead of `$pdf.pages`

## Testing
- `npm test` (fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/jsreport-gmp/package.json')

------
https://chatgpt.com/codex/tasks/task_e_689a0eb34c7c832ebab2d5c72a88606c