### PR TITLE
Fix assets for candidate report and ensure chrome PDF ready

### DIFF
--- a/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/config.json
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/config.json
@@ -25,10 +25,5 @@
     "inheritedReadPermissions": [],
     "inheritedEditPermissions": [],
     "_id": "intel_template_id",
-    "$entitySet": "templates",
-    "scripts": [
-        {
-            "shortid": "IntelScript"
-        }
-    ]
+    "$entitySet": "templates"
 }

--- a/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/content.handlebars
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/content.handlebars
@@ -12,7 +12,7 @@
   <header class="main-header" data-breadcrumb="Cabecera">
     <div class="header-grid">
       <div class="brand-section">
-        <img src="{{assetUrl 'logos/grupoempleo-logo.png'}}" alt="GrupoEmpleo" class="logo">
+        <img src="{{asset 'logos/grupoempleo-logo.svg' @encoding=dataURI}}" alt="GrupoEmpleo" class="logo">
         <div class="brand-text">
           <h1 class="brand-name">GRUPO EMPLEO</h1>
           <p class="brand-tagline">Recursos Humanos · Sector Industrial</p>
@@ -31,9 +31,9 @@
     <div class="candidate-grid">
       <div class="candidate-photo-wrapper">
         {{#if datosPersonales.foto}}
-          <img src="{{datosPersonales.foto}}" alt="Foto" class="candidate-photo">
+          <img src="{{asset (concat 'profiles/' datosPersonales.foto) @encoding=dataURI}}" alt="Foto" class="candidate-photo">
         {{else}}
-          <img src="{{assetUrl 'profiles/candidate-neutral-01.jpg'}}" alt="Foto" class="candidate-photo">
+          <img src="{{asset 'profiles/candidate-neutral-01.svg' @encoding=dataURI}}" alt="Foto" class="candidate-photo">
         {{/if}}
       </div>
       <div class="candidate-info">
@@ -159,8 +159,8 @@
   </footer>
 
   <!-- MEASUREMENT SERVICE -->
+  <script>{{{asset "../measurement-service.js"}}}</script>
   <script>
-    // Se inyectará desde measurement-service.js
     if (typeof window.MeasurementService !== 'undefined') {
       const service = new window.MeasurementService();
       service.initialize();

--- a/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/helpers.js
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/helpers.js
@@ -158,11 +158,20 @@ function or() {
 function and() {
   const args = Array.prototype.slice.call(arguments, 0, -1);
   const options = arguments[arguments.length - 1];
-  
+
   if (args.every(Boolean)) {
     return options.fn(this);
   }
   return options.inverse(this);
+}
+
+/**
+ * Concatena múltiples cadenas
+ * @param {...string} args - Cadenas a unir
+ * @returns {string} Resultado de la concatenación
+ */
+function concat() {
+  return Array.prototype.slice.call(arguments, 0, -1).join('');
 }
 
 /**

--- a/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligenteData/dataJson.json
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligenteData/dataJson.json
@@ -11,7 +11,7 @@
         "idInformeCvPublicacionDatosPersonales": 10006,
         "idInformeCvPublicacion": 10006,
         "nombreCompleto": "Alberto Delgado Ortiz",
-        "foto": "34528.jpg",
+        "foto": "",
         "codigoPostal": "48903",
         "municipio": "Barakaldo",
         "pais": "Espa\u00F1a",

--- a/data/informes/informesSeleccion/informeSeleccionInteligente/measurement-service.js/config.json
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/measurement-service.js/config.json
@@ -1,6 +1,5 @@
 {
     "name": "measurement-service.js",
-    "scope": "global",
     "creationDate": {
         "$$date": 1723701000000
     },
@@ -11,5 +10,5 @@
     "inheritedReadPermissions": [],
     "inheritedEditPermissions": [],
     "_id": "intel_script_id",
-    "$entitySet": "scripts"
+    "$entitySet": "assets"
 }


### PR DESCRIPTION
## Summary
- inline logo and candidate image assets via data URI
- load measurement service script as asset and add concat helper
- remove unused script reference and default missing photo

## Testing
- `node --check data/informes/informesSeleccion/informeSeleccionInteligente/informeInteligente/helpers.js`
- `node --check data/informes/informesSeleccion/informeSeleccionInteligente/measurement-service.js/content.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2cb60b2a0832ea7ff45d25761e700