### PR TITLE
docs: update logo references to svg

### DIFF
--- a/data/FASE1_IMPLEMENTACION_COMPLETAInformeInteligente01.md
+++ b/data/FASE1_IMPLEMENTACION_COMPLETAInformeInteligente01.md
@@ -18,7 +18,7 @@ Se ha completado exitosamente la **FASE 1 - FUNDAMENTOS** del Sistema Inteligent
 
 /data/assets/
 ├── logos/
-│   └── grupoempleo-logo.png    # Logo placeholder
+│   └── grupoempleo-logo.svg    # Logo placeholder
 ├── profiles/
 │   ├── candidate-male-01.jpg
 │   ├── candidate-female-01.jpg

--- a/data/informes/informesSeleccion/informeSeleccionInteligente/README.md
+++ b/data/informes/informesSeleccion/informeSeleccionInteligente/README.md
@@ -7,7 +7,7 @@ Esta carpeta contiene los recursos gráficos necesarios para el proyecto informe
 ```
 /data/assets/
 ├── logos/
-│   └── grupoempleo-logo.png       # Logo corporativo (placeholder)
+│   └── grupoempleo-logo.svg       # Logo corporativo (placeholder)
 ├── profiles/
 │   ├── candidate-male-01.jpg      # Foto placeholder hombre
 │   ├── candidate-female-01.jpg    # Foto placeholder mujer
@@ -20,9 +20,9 @@ Esta carpeta contiene los recursos gráficos necesarios para el proyecto informe
 ## Especificaciones Técnicas
 
 ### Logos
-- **Formato**: PNG con transparencia
+- **Formato**: SVG vectorial
 - **Tamaño**: 200x60px (ratio 10:3)
-- **Resolución**: 300 DPI para impresión
+- **Resolución**: infinita (escalable)
 - **Colores**: Paleta corporativa GrupoEmpleo
 
 ### Profiles  


### PR DESCRIPTION
## Summary
- replace stale grupoempleo logo references pointing to PNG with SVG variant

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d43781dc832ea09e3168d511c24f